### PR TITLE
_ is an allowed character in XHP tag names.

### DIFF
--- a/after/syntax/php.vim
+++ b/after/syntax/php.vim
@@ -16,7 +16,7 @@ endif
 
 " Highlight XHP regions as XML; recursively match.
 syn region  xhpRegion contains=@XMLSyntax,xhpRegion,xhpContent
-  \ start=+<\@<!<\z([a-zA-Z0-9:\-]\+\)+
+  \ start=+<\@<!<\z([a-zA-Z0-9:\-_]\+\)+
   \ skip=+<!--\_.\{-}-->+
   \ end=+</\z1\_\s\{-}>+
   \ end=+/>+


### PR DESCRIPTION
I've got a bunch of XHP custom tags that use _ in multiword names.  Love this plugin, this makes it work a tiny bit better in my use case.
